### PR TITLE
Add minimal Node.js server for sharedlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # sharedlinks
+
+A minimal Node.js HTTP server.
+
+## Run locally
+
+```bash
+npm start
+```
+
+Server defaults to port `3000`.
+
+## Endpoints
+
+- `GET /health` → returns `{ "status": "ok" }`
+- `GET /` (or any other path) → returns request info

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "sharedlinks",
+  "version": "1.0.0",
+  "description": "Simple Node.js server for sharedlinks",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "license": "MIT"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,24 @@
+const http = require('http');
+
+const PORT = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok' }));
+    return;
+  }
+
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(
+    JSON.stringify({
+      message: 'SharedLinks Node.js server is running',
+      path: req.url,
+      method: req.method,
+    })
+  );
+});
+
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
### Motivation

- Provide a lightweight local HTTP server for the repository to enable quick health checks and basic endpoint testing.
- Keep the implementation dependency-free to make it easy to run in CI or local development without extra setup.

### Description

- Add `server.js` implementing a minimal Node.js HTTP server with a `GET /health` endpoint and JSON responses for other paths.
- Add `package.json` with a `start` script (`npm start`) to run the server.
- Add `.gitignore` entries for `node_modules/` and `.env` to avoid committing environment and dependency artifacts.
- Update `README.md` with run instructions and documented endpoints.

### Testing

- Verified Node and npm are available with `node -v && npm -v`, which succeeded.
- Started the server with `node server.js` and validated `GET /health` returned `{ "status": "ok" }` and an arbitrary route returned request info JSON, which all succeeded.
- Attempted `git push` but it failed because no remote push destination is configured for this repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993366e29bc8327a717b77f9508f35c)